### PR TITLE
Expose diff interface

### DIFF
--- a/lib/gitlab_git/wrapper.rb
+++ b/lib/gitlab_git/wrapper.rb
@@ -12,8 +12,8 @@ module Gitlab
 
       attr_reader :gitlab
       delegate :bare?, :branches, :branch_count, :branch_exists?, :branch_names,
-               :commit_count, :find_commits, :empty?, :log, :ls_files, :rugged,
-               to: :gitlab
+               :commit_count, :diff, :find_commits, :empty?, :log, :ls_files,
+               :rugged, to: :gitlab
 
       def self.create(path)
         raise Error, "Path #{path} already exists." if Pathname.new(path).exist?

--- a/lib/gitlab_git/wrapper.rb
+++ b/lib/gitlab_git/wrapper.rb
@@ -78,6 +78,10 @@ module Gitlab
       def create_branch(name, ref)
         gitlab.create_branch(name, ref)
       end
+
+      def diff_from_parent(ref = default_branch, options = {})
+        Commit.find(gitlab, ref).diffs(options)
+      end
     end
   end
 end


### PR DESCRIPTION
This shall expose a convenient diff interface.

`diff` diffs a range while `diff_from_parent` diffs only a single commit. If the `from` parameter in `diff` is `nil`, the diff is created from the root/empty repository.