### PR TITLE
Add interface for tags

### DIFF
--- a/lib/gitlab_git/blame.rb
+++ b/lib/gitlab_git/blame.rb
@@ -16,7 +16,7 @@ module Gitlab
       def each
         @blames.each do |blame|
           yield(
-            Gitlab::Git::Commit.new(blame.commit),
+            Gitlab::Git::Commit.new(blame.commit, @repo),
             blame.line
           )
         end

--- a/lib/gitlab_git/branch.rb
+++ b/lib/gitlab_git/branch.rb
@@ -1,6 +1,9 @@
 module Gitlab
   module Git
     class Branch < Ref
+      def self.find(repository,name)
+        repository.branches.find { |branch| branch.name == name }
+      end
     end
   end
 end

--- a/lib/gitlab_git/ref.rb
+++ b/lib/gitlab_git/ref.rb
@@ -3,6 +3,14 @@ module Gitlab
     class Ref
       include Gitlab::Git::EncodingHelper
 
+      def self.name_valid?(name)
+        return false if name.start_with?('refs/heads/')
+        return false if name.start_with?('refs/remotes/')
+
+        Popen.popen(%W(git check-ref-format refs/#{name})).last == 0
+      end
+
+
       # Branch or tag name
       # without "refs/tags|heads" prefix
       attr_reader :name

--- a/lib/gitlab_git/ref.rb
+++ b/lib/gitlab_git/ref.rb
@@ -4,8 +4,9 @@ module Gitlab
       include Gitlab::Git::EncodingHelper
 
       def self.name_valid?(name)
-        return false if name.start_with?('refs/heads/')
-        return false if name.start_with?('refs/remotes/')
+        if name.start_with?('refs/heads/') || name.start_with?('refs/remotes/')
+          return false
+        end
 
         Popen.popen(%W(git check-ref-format refs/#{name})).last == 0
       end

--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -467,7 +467,7 @@ module Gitlab
         offset = actual_options[:skip]
         limit = actual_options[:max_count]
         walker.each(offset: offset, limit: limit) do |commit|
-          gitlab_commit = Gitlab::Git::Commit.decorate(commit)
+          gitlab_commit = Gitlab::Git::Commit.decorate(commit, self)
           commits.push(gitlab_commit)
         end
 

--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -261,7 +261,7 @@ module Gitlab
           # Skip binary files
           next if blob.data.encoding == Encoding::ASCII_8BIT
 
-          blob.load_all_data!(self)
+          blob.load_all_data!
           greps += build_greps(blob.data, query, ref, entry[:path])
         end
 

--- a/lib/gitlab_git/tag.rb
+++ b/lib/gitlab_git/tag.rb
@@ -3,6 +3,10 @@ module Gitlab
     class Tag < Ref
       attr_reader :object_sha
 
+      def self.find(repository, name)
+        repository.tags.find { |tag| tag.name == name }
+      end
+
       def initialize(repository, name, target, message = nil)
         super(repository, name, target)
 

--- a/lib/gitlab_git/wrapper.rb
+++ b/lib/gitlab_git/wrapper.rb
@@ -77,6 +77,7 @@ module Gitlab
 
       # Create a branch with name +name+ at the reference +ref+.
       def create_branch(name, revision)
+        raise_invalid_name_error(name) unless Ref.name_valid?(name)
         gitlab.create_branch(name, revision)
       end
 
@@ -98,7 +99,7 @@ module Gitlab
       # :message ::
       #   An optional string containing the message for the new tag.
       def create_tag(name, revision, annotation = nil)
-        raise ::Gitlab::Git::InvalidRefName unless Ref.name_valid?(name)
+        raise_invalid_name_error(name) unless Ref.name_valid?(name)
         rugged.tags.create(name, revision, annotation)
         find_tag(name)
       rescue Rugged::TagError => error
@@ -115,6 +116,14 @@ module Gitlab
 
       def diff_from_parent(ref = default_branch, options = {})
         Commit.find(gitlab, ref).diffs(options)
+      end
+
+      protected
+
+      def raise_invalid_name_error(name)
+        url = 'https://git-scm.com/docs/git-check-ref-format'
+        raise ::Gitlab::Git::InvalidRefName,
+          %(Name "#{name}" is invalid. See #{url} for a valid format.)
       end
     end
   end

--- a/lib/gitlab_git/wrapper.rb
+++ b/lib/gitlab_git/wrapper.rb
@@ -76,8 +76,16 @@ module Gitlab
       end
 
       # Create a branch with name +name+ at the reference +ref+.
-      def create_branch(name, ref)
-        gitlab.create_branch(name, ref)
+      def create_branch(name, revision)
+        gitlab.create_branch(name, revision)
+      end
+
+      def find_branch(name)
+        Gitlab::Git::Branch.find(self, name)
+      end
+
+      def rm_branch(name)
+        rugged.branches.delete(name) if find_branch(name)
       end
 
       # If +annotation+ is not +nil+, it will cause the creation of an

--- a/spec/blob_spec.rb
+++ b/spec/blob_spec.rb
@@ -6,7 +6,7 @@ describe Gitlab::Git::Blob, seed_helper: true do
   let(:repository) { Gitlab::Git::Repository.new(TEST_REPO_PATH) }
 
   describe :initialize do
-    let(:blob) { Gitlab::Git::Blob.new(name: 'test') }
+    let(:blob) { Gitlab::Git::Blob.new(repository, name: 'test') }
 
     it 'handles nil data' do
       expect(blob.name).to eq('test')
@@ -66,7 +66,7 @@ describe Gitlab::Git::Blob, seed_helper: true do
       it { expect(blob.data).to eq('') }
 
       it 'does not get messed up by load_all_data!' do
-        blob.load_all_data!(repository)
+        blob.load_all_data!
         expect(blob.data).to eq('')
       end
 
@@ -87,13 +87,13 @@ describe Gitlab::Git::Blob, seed_helper: true do
       end
 
       it 'can load all data' do
-        blob.load_all_data!(repository)
+        blob.load_all_data!
         expect(blob.data.length).to eq(blob_size)
       end
 
       it 'marks the blob as binary' do
         expect(Gitlab::Git::Blob).to receive(:new).
-          with(hash_including(binary: true)).
+          with(repository, hash_including(binary: true)).
           and_call_original
 
         expect(blob).to be_binary
@@ -120,7 +120,7 @@ describe Gitlab::Git::Blob, seed_helper: true do
         expect(blob.data.length).to eq(Gitlab::Git::Blob::MAX_DATA_DISPLAY_SIZE)
         expect(blob.truncated?).to be_truthy
 
-        blob.load_all_data!(repository)
+        blob.load_all_data!
         expect(blob.loaded_size).to eq(blob_size)
       end
     end

--- a/spec/branch_spec.rb
+++ b/spec/branch_spec.rb
@@ -27,5 +27,35 @@ describe Gitlab::Git::Branch, seed_helper: true do
     it { expect(branch.dereferenced_target.sha).to eq(SeedRepo::LastCommit::ID) }
   end
 
+  describe 'find' do
+    RSpec.shared_examples 'the correctly found branch' do
+      it 'points to the correct commit' do
+        expect(found_branch.dereferenced_target.sha).
+          to eq(base_branch.dereferenced_target.sha)
+      end
+
+      it 'has the correct name' do
+        expect(found_branch.name).to eq(base_branch.name)
+      end
+    end
+
+    context 'finds the first branch' do
+      let(:base_branch) { repository.branches.first }
+      let(:found_branch) { Gitlab::Git::Branch.find(repository, base_branch.name) }
+      it_behaves_like 'the correctly found branch'
+    end
+
+    context 'finds the last branch' do
+      let(:base_branch) { repository.branches.last }
+      let(:found_branch) { Gitlab::Git::Branch.find(repository, base_branch.name) }
+      it_behaves_like 'the correctly found branch'
+    end
+
+    it 'returns nil on a non-existant branch' do
+      expect(Gitlab::Git::Branch.find(repository, 'non existant branch.')).
+        to be(nil)
+    end
+  end
+
   it { expect(repository.branches.size).to eq(SeedRepo::Repo::BRANCHES.size) }
 end

--- a/spec/commit_spec.rb
+++ b/spec/commit_spec.rb
@@ -24,7 +24,8 @@ describe Gitlab::Git::Commit, seed_helper: true do
       }
 
       @parents = [repo.head.target]
-      @gitlab_parents = @parents.map { |c| Gitlab::Git::Commit.decorate(c) }
+      @gitlab_parents =
+        @parents.map { |c| Gitlab::Git::Commit.decorate(c, repo) }
       @tree = @parents.first.tree
 
       sha = Rugged::Commit.create(
@@ -38,7 +39,7 @@ describe Gitlab::Git::Commit, seed_helper: true do
       )
 
       @raw_commit = repo.lookup(sha)
-      @commit = Gitlab::Git::Commit.new(@raw_commit)
+      @commit = Gitlab::Git::Commit.new(@raw_commit, repo)
     end
 
     it { expect(@commit.short_id).to eq(@raw_commit.oid[0..10]) }
@@ -305,7 +306,7 @@ describe Gitlab::Git::Commit, seed_helper: true do
   end
 
   describe :init_from_rugged do
-    let(:gitlab_commit) { Gitlab::Git::Commit.new(rugged_commit) }
+    let(:gitlab_commit) { Gitlab::Git::Commit.new(rugged_commit, repository) }
     subject { gitlab_commit }
 
     describe '#id' do
@@ -315,7 +316,7 @@ describe Gitlab::Git::Commit, seed_helper: true do
   end
 
   describe :init_from_hash do
-    let(:commit) { Gitlab::Git::Commit.new(sample_commit_hash) }
+    let(:commit) { Gitlab::Git::Commit.new(sample_commit_hash, repository) }
     subject { commit }
 
     describe '#id' do
@@ -383,7 +384,7 @@ describe Gitlab::Git::Commit, seed_helper: true do
 
   describe :ref_names do
     let(:commit) { Gitlab::Git::Commit.find(repository, 'master') }
-    subject { commit.ref_names(repository) }
+    subject { commit.ref_names }
 
     it 'has 1 element' do
       expect(subject.size).to eq(1)

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -21,5 +21,41 @@ describe Gitlab::Git::Tag, seed_helper: true do
     it { expect(tag.message).to eq("Version 1.2.1") }
   end
 
+  describe 'find' do
+    RSpec.shared_examples 'the correctly found tag' do
+      it 'points to the correct commit' do
+        expect(found_tag.dereferenced_target.id).
+          to eq(base_tag.dereferenced_target.id)
+      end
+
+      it 'has the correct name' do
+        expect(found_tag.name).to eq(base_tag.name)
+      end
+
+      it 'has the correct message' do
+        expect(found_tag.message).to eq(base_tag.message)
+      end
+    end
+
+    context 'finds the first tag' do
+      let(:base_tag) { repository.tags.first }
+      let(:found_tag) { Gitlab::Git::Tag.find(repository, base_tag.name) }
+      it_behaves_like 'the correctly found tag'
+    end
+
+    context 'finds the last tag' do
+      let(:base_tag) { repository.tags.last }
+      let(:found_tag) { Gitlab::Git::Tag.find(repository, base_tag.name) }
+      it_behaves_like 'the correctly found tag'
+    end
+
+    it 'returns nil on a non-existant tag' do
+      # This name cannot be a tag. See
+      # https://git-scm.com/docs/git-check-ref-format:
+      # 7. They cannot end with a dot `.`.
+      expect(Gitlab::Git::Tag.find(repository, 'non existant tag.')).to be(nil)
+    end
+  end
+
   it { expect(repository.tags.size).to eq(SeedRepo::Repo::TAGS.size) }
 end

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -461,7 +461,7 @@ RSpec.describe(Gitlab::Git::Wrapper) do
         it 'fails' do
           expect { subject.create_branch(name, revision) }.
             to raise_error(Rugged::OdbError,
-                           /object not found - no match for id/)
+                           /object not found - no match for id/i)
         end
       end
     end
@@ -623,7 +623,7 @@ RSpec.describe(Gitlab::Git::Wrapper) do
         it 'fails' do
           expect { subject.create_tag(name, revision) }.
             to raise_error(Rugged::OdbError,
-                           /object not found - no match for id/)
+                           /object not found - no match for id/i)
         end
       end
 

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -455,6 +455,15 @@ RSpec.describe(Gitlab::Git::Wrapper) do
           expect(subject.branches.size).to eq(2)
         end
       end
+
+      context 'bad revision' do
+        let(:revision) { '0' * 40 }
+        it 'fails' do
+          expect { subject.create_branch(name, revision) }.
+            to raise_error(Rugged::OdbError,
+                           /object not found - no match for id/)
+        end
+      end
     end
 
     context 'find_branch' do
@@ -606,6 +615,15 @@ RSpec.describe(Gitlab::Git::Wrapper) do
 
         it 'has the correct number of tags' do
           expect(subject.tags.size).to eq(1)
+        end
+      end
+
+      context 'bad revision' do
+        let(:revision) { '0' * 40 }
+        it 'fails' do
+          expect { subject.create_tag(name, revision) }.
+            to raise_error(Rugged::OdbError,
+                           /object not found - no match for id/)
         end
       end
 

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe(Gitlab::Git::Wrapper) do
         it 'fails' do
           expect { subject.create_tag(name, branch) }.
             to raise_error(Gitlab::Git::Repository::InvalidRef,
-                           'tag already exists')
+                           'Tag already exists')
         end
 
         it 'has the correct number of tags' do

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -423,6 +423,22 @@ RSpec.describe(Gitlab::Git::Wrapper) do
         end
       end
 
+      context 'invalid name' do
+        it 'fails' do
+          expect { subject.create_branch("#{name}.", branch) }.
+            to raise_error(Gitlab::Git::InvalidRefName)
+        end
+
+        it 'has the correct number of branches' do
+          expect do
+            begin
+              subject.create_branch("#{name}.", branch)
+            rescue Gitlab::Git::InvalidRefName
+            end
+          end.not_to(change { subject.branches.size })
+        end
+      end
+
       context 'duplicate' do
         before do
           subject.create_branch(name, sha2)

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -423,6 +423,179 @@ RSpec.describe(Gitlab::Git::Wrapper) do
     end
   end
 
+  context 'tags' do
+    let!(:sha1) do
+      subject.create_file(FactoryGirl.create(:git_commit_info, branch: branch))
+    end
+
+    let!(:sha2) do
+      subject.create_file(FactoryGirl.create(:git_commit_info, branch: branch))
+    end
+
+    let(:name) { 'new_tag' }
+
+    context 'create_tag' do
+      let(:created_tag) do
+        subject.tags.select { |tag| tag.name == name }.first
+      end
+
+      RSpec.shared_examples 'a valid tag' do
+        it 'points to the correct sha' do
+          expect(created_tag.dereferenced_target.id).to eq(sha)
+        end
+
+        it 'has the correct name' do
+          expect(created_tag.name).to eq(name)
+        end
+      end
+
+      context 'by sha' do
+        before { subject.create_tag(name, sha1) }
+
+        it_behaves_like 'a valid tag' do
+          let(:sha) { sha1 }
+        end
+
+        it 'is not annotated' do
+          expect(created_tag.message).to be(nil)
+        end
+
+        it 'has the correct number of tags' do
+          expect(subject.tags.size).to eq(1)
+        end
+      end
+
+      context 'by branch' do
+        before { subject.create_tag(name, branch) }
+
+        it_behaves_like 'a valid tag' do
+          let(:sha) { sha2 }
+        end
+
+        it 'has the correct number of tags' do
+          expect(subject.tags.size).to eq(1)
+        end
+      end
+
+      context 'by rev' do
+        before { subject.create_tag(name, "#{branch}~1") }
+
+        it_behaves_like 'a valid tag' do
+          let(:sha) { sha1 }
+        end
+
+        it 'has the correct number of tags' do
+          expect(subject.tags.size).to eq(1)
+        end
+      end
+
+      context 'invalid name' do
+        it 'fails' do
+          expect { subject.create_tag("#{name}.", branch) }.
+            to raise_error(Gitlab::Git::InvalidRefName)
+        end
+
+        it 'has the correct number of tags' do
+          expect do
+            begin
+              subject.create_tag("#{name}.", branch)
+            rescue Gitlab::Git::InvalidRefName
+            end
+          end.not_to(change { subject.tags.size })
+        end
+      end
+
+      context 'duplicate' do
+        before do
+          subject.create_tag(name, branch)
+        end
+
+        it 'fails' do
+          expect { subject.create_tag(name, branch) }.
+            to raise_error(Gitlab::Git::Repository::InvalidRef,
+                           'tag already exists')
+        end
+
+        it 'has the correct number of tags' do
+          expect(subject.tags.size).to eq(1)
+        end
+      end
+
+      context 'with message' do
+        let(:message) { "test tag message\nwith many\nlines\n" }
+        let(:tagger) do
+          FactoryGirl.create(:git_commit_info)[:author]
+        end
+        before do
+          subject.create_tag(name, branch, {message: message, tagger: tagger})
+        end
+
+        it_behaves_like 'a valid tag' do
+          let(:sha) { subject.branch_sha(branch) }
+        end
+
+        it 'has an annotation' do
+          expect(created_tag.message).to eq(message.strip)
+        end
+      end
+    end
+
+    context 'find_tag' do
+      before do
+        subject.create_tag("pre_#{name}", sha1)
+        subject.create_tag(name, sha2)
+      end
+
+      let(:base_tag) { Gitlab::Git::Tag.find(subject, name) }
+      let(:found_tag) { subject.find_tag(name) }
+
+      it 'points to the correct commit' do
+        expect(found_tag.dereferenced_target.id).
+          to eq(base_tag.dereferenced_target.id)
+      end
+
+      it 'has the correct name' do
+        expect(found_tag.name).to eq(base_tag.name)
+      end
+
+      it 'has the correct message' do
+        expect(found_tag.message).to eq(base_tag.message)
+      end
+    end
+
+    context 'rm_tag' do
+      before do
+        subject.create_tag("pre_#{name}", sha1)
+        subject.create_tag(name, sha2)
+      end
+
+      context 'with an existing tag' do
+        before { subject.rm_tag(name) }
+
+        it 'the deleted tag cannot be found' do
+          expect(Gitlab::Git::Tag.find(subject, name)).to be(nil)
+        end
+
+        it 'the other tag can still be found' do
+          expect(Gitlab::Git::Tag.find(subject, "pre_#{name}")).
+            not_to be(nil)
+        end
+
+        it 'reduces the number of tags' do
+          expect(subject.tags.size).to eq(1)
+        end
+      end
+
+      context 'with an inexistant tag' do
+        before { subject.rm_tag('inexistant.') }
+
+        it 'does not reduce the number of tags' do
+          expect(subject.tags.size).to eq(2)
+        end
+      end
+    end
+  end
+
   context 'ls_files' do
     let(:filepaths) { (1..5).map { generate(:filepath) } }
     before do


### PR DESCRIPTION
This adds the methods `wrapper.find_tag`, `wrapper.tags`, `wrapper.tag_names`, `wrapper.create_tag`, `wrapper.rm_tag` as well as `wrapper.find_branch`, `wrapper.rm_branch` as well as `find` on `Tag` and `Branch`.