### PR TITLE
Fix the log.

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -338,7 +338,7 @@ module Gitlab
         limit += offset if offset_in_ruby
 
         cmd = %W[git --git-dir=#{path} log]
-        cmd << "--max-count=#{limit}"
+        cmd << "--max-count=#{limit}" if limit > 0
         cmd << '--format=%H'
         cmd << "--skip=#{offset}" unless offset_in_ruby
         cmd << '--follow' if use_follow_flag

--- a/lib/gitlab_git/wrapper.rb
+++ b/lib/gitlab_git/wrapper.rb
@@ -13,7 +13,7 @@ module Gitlab
 
       attr_reader :gitlab
       delegate :bare?, :branches, :branch_count, :branch_exists?, :branch_names,
-               :commit_count, :diff, :find_commits, :empty?, :log, :ls_files,
+               :commit_count, :diff, :find_commits, :empty?, :ls_files,
                :rugged, :tag_names, :tags, to: :gitlab
 
       def self.create(path)
@@ -116,6 +116,12 @@ module Gitlab
 
       def diff_from_parent(ref = default_branch, options = {})
         Commit.find(gitlab, ref).diffs(options)
+      end
+
+      def log(*args)
+        gitlab.log(*args).map do |commit|
+          Gitlab::Git::Commit.new(commit, gitlab)
+        end
       end
 
       protected

--- a/spec/committing_spec.rb
+++ b/spec/committing_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe(Gitlab::Git::Committing) do
           end
 
           it 'creates the correct number of commits on that file' do
-            expect(subject.log(ref: branch, path: filepath).map(&:oid)).
+            expect(subject.log(ref: branch, path: filepath).map(&:id)).
               to eq([sha])
           end
 
@@ -75,7 +75,7 @@ RSpec.describe(Gitlab::Git::Committing) do
           end
 
           it 'creates the correct number of commits on that file' do
-            expect(subject.log(ref: branch, path: filepath).map(&:oid)).
+            expect(subject.log(ref: branch, path: filepath).map(&:id)).
               to eq([sha2, sha1])
           end
 
@@ -109,7 +109,7 @@ RSpec.describe(Gitlab::Git::Committing) do
           end
 
           it 'creates the correct number of commits on that file' do
-            expect(subject.log(ref: branch, path: filepath2).map(&:oid)).
+            expect(subject.log(ref: branch, path: filepath2).map(&:id)).
               to eq([sha2])
           end
 
@@ -149,7 +149,7 @@ RSpec.describe(Gitlab::Git::Committing) do
           end
 
           it 'creates the correct number of commits on that file' do
-            expect(subject.log(ref: branch, path: filepath2).map(&:oid)).
+            expect(subject.log(ref: branch, path: filepath2).map(&:id)).
               to eq([sha2])
           end
 
@@ -179,7 +179,7 @@ RSpec.describe(Gitlab::Git::Committing) do
           end
 
           it 'creates the correct number of commits on that file' do
-            expect(subject.log(ref: branch, path: filepath).map(&:oid)).
+            expect(subject.log(ref: branch, path: filepath).map(&:id)).
               to eq([sha2, sha1])
           end
 
@@ -305,7 +305,7 @@ RSpec.describe(Gitlab::Git::Committing) do
           end
 
           it 'only adds one log entry' do
-            expect(subject.log(ref: "#{branch}~").first.oid).
+            expect(subject.log(ref: "#{branch}~").first.id).
               to eq(setup_commits.last)
           end
         end

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -888,4 +888,24 @@ RSpec.describe(Gitlab::Git::Wrapper) do
       end
     end
   end
+
+  context 'log' do
+    let(:num_setup_commits) { 6 }
+    let!(:file_range) { (0 .. num_setup_commits - 1) }
+    let!(:old_files) { file_range.map { generate(:filepath) } }
+    let!(:old_contents) { file_range.map { generate(:content) } }
+    let!(:setup_commits) do
+      file_range.map do |i|
+        subject.create_file(create(:git_commit_info,
+                                   filepath: old_files[i],
+                                   content: old_contents[i],
+                                   branch: branch))
+      end
+    end
+
+    it 'contains objects of the correct class' do
+      expect(subject.log(ref: branch).map(&:class).uniq).
+        to eq([Gitlab::Git::Commit])
+    end
+  end
 end


### PR DESCRIPTION
The log returned `Rugged::Commit` objects, but we need them to be `Gitlab::Git::Commit` objects in the backend. This wraps them.

It also fixes retrieving the log by shell if no limit is supplied