### PR TITLE
Fix empty path git warnings

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -347,7 +347,7 @@ module Gitlab
         cmd << "--before=#{options[:before].iso8601}" if options[:before]
         cmd << sha
         if options[:path].present?
-          cmd += %W[-- #{options[:path].sub(%r{\A/*}, '')}]
+          cmd += %W[-- #{options[:path].sub(%r{\A/*}, './')}]
         end
 
         raw_output = IO.popen(cmd) { |io| io.read }

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -733,22 +733,46 @@ describe Gitlab::Git::Repository, seed_helper: true do
 
       it { expect(commits_by_walk).to eq(commits_by_shell) }
 
-      context "with limit" do
-        let(:options) { { ref: "master", limit: 1 } }
+      context "without path" do
+        context "with limit" do
+          let(:options) { { ref: "master", limit: 1 } }
 
-        it { expect(commits_by_walk).to eq(commits_by_shell) }
+          it { expect(commits_by_walk).to eq(commits_by_shell) }
+        end
+
+        context "with offset" do
+          let(:options) { { ref: "master", offset: 1 } }
+
+          it { expect(commits_by_walk).to eq(commits_by_shell) }
+        end
+
+        context "with skip_merges" do
+          let(:options) { { ref: "master", skip_merges: true } }
+
+          it { expect(commits_by_walk).to eq(commits_by_shell) }
+        end
       end
 
-      context "with offset" do
-        let(:options) { { ref: "master", offset: 1 } }
+      context "with root path" do
+        let(:path) { "/" }
 
-        it { expect(commits_by_walk).to eq(commits_by_shell) }
-      end
+        context "with limit" do
+          let(:options) { { ref: "master", limit: 1, path: path } }
 
-      context "with skip_merges" do
-        let(:options) { { ref: "master", skip_merges: true } }
+          it { expect(commits_by_walk).to eq(commits_by_shell) }
+        end
 
-        it { expect(commits_by_walk).to eq(commits_by_shell) }
+        context "with offset" do
+          let(:options) { { ref: "master", offset: 1, path: path } }
+
+          it { expect(commits_by_walk).to eq(commits_by_shell) }
+        end
+
+        context "with skip_merges" do
+          let(:options) { { ref: "master", skip_merges: true, path: path } }
+
+          it { expect(commits_by_walk).to eq(commits_by_shell) }
+        end
       end
 
       context "with path" do


### PR DESCRIPTION
This replaces all leading `/` in the log path by `./` and prepends it to paths not starting with `/` (for consistency).