### PR TITLE
Add options "unsafe_range" and "only_commit_sha" to log

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -329,7 +329,12 @@ module Gitlab
           limit: options[:limit],
           offset: options[:offset]
         }
-        Rugged::Walker.walk(rugged, walk_options).to_a
+        commits = Rugged::Walker.walk(rugged, walk_options).to_a
+        if options[:only_commit_sha]
+          commits.map(&:oid)
+        else
+          commits
+        end
       end
 
       def log_by_shell(sha, options)
@@ -358,7 +363,11 @@ module Gitlab
         raw_output = IO.popen(cmd) { |io| io.read }
         lines = offset_in_ruby ? raw_output.lines.drop(offset) : raw_output.lines
 
-        lines.map! { |c| Rugged::Commit.new(rugged, c.strip) }
+        if options[:only_commit_sha]
+          lines.map(&:strip)
+        else
+          lines.map! { |c| Rugged::Commit.new(rugged, c.strip) }
+        end
       end
 
       def count_commits(options)

--- a/lib/gitlab_git/wrapper.rb
+++ b/lib/gitlab_git/wrapper.rb
@@ -118,8 +118,10 @@ module Gitlab
         Commit.find(gitlab, ref).diffs(options)
       end
 
-      def log(*args)
-        gitlab.log(*args).map do |commit|
+      def log(options)
+        result = gitlab.log(options)
+        return result if options[:only_commit_sha]
+        result.map do |commit|
           Gitlab::Git::Commit.new(commit, gitlab)
         end
       end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -726,6 +726,16 @@ describe Gitlab::Git::Repository, seed_helper: true do
       end
     end
 
+    context "only_commit_sha" do
+      let(:options) { { ref: "master", only_commit_sha: true } }
+      let(:commits_by_walk) { repository.log(options) }
+      let(:commits_by_shell) { repository.log(options.merge(disable_walk: true)) }
+
+      it { expect(commits_by_walk).to eq(commits_by_shell) }
+
+      it { expect(commits_by_walk.first).to match(/[a-z0-9]{40}/) }
+    end
+
     context "compare results between log_by_walk and log_by_shell" do
       let(:options) { { ref: "master" } }
       let(:commits_by_walk) { repository.log(options).map(&:oid) }

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -903,6 +903,11 @@ RSpec.describe(Gitlab::Git::Wrapper) do
       end
     end
 
+    it 'contains objects of the correct class when given only_commit_sha' do
+      expect(subject.log(ref: branch, only_commit_sha: true).map(&:class).uniq).
+        to eq([String])
+    end
+
     it 'contains objects of the correct class' do
       expect(subject.log(ref: branch).map(&:class).uniq).
         to eq([Gitlab::Git::Commit])

--- a/spec/wrapper_spec.rb
+++ b/spec/wrapper_spec.rb
@@ -907,5 +907,17 @@ RSpec.describe(Gitlab::Git::Wrapper) do
       expect(subject.log(ref: branch).map(&:class).uniq).
         to eq([Gitlab::Git::Commit])
     end
+
+    it 'allows to specify ranges' do
+      expect(subject.log(ref: "#{setup_commits[2]}..#{setup_commits[4]}",
+                         unsafe_range: true).map(&:id)).
+        to eq(setup_commits[3..4].reverse)
+    end
+
+    it 'allows to specify open ranges' do
+      expect(subject.log(ref: "#{setup_commits[2]}..",
+                         unsafe_range: true).map(&:id)).
+        to eq(setup_commits[3..-1].reverse)
+    end
   end
 end


### PR DESCRIPTION
This adds two options to the `log` method:

* `unsafe_range` allows to use ranges like `ref1..ref2` or `ref1..` in the log. This is unsafe because the refs in the range might not be on a common path. In that case, the git command line tool will print an error message and the return value will be an empty array.
* `only_commit_sha` will not gather commit objects, but only their hash. This dramatically speeds up the computation. Instead of 7.5 seconds, this only takes 0.25 seconds on a repository with 20000 commits.