### PR TITLE
Use RSpec progress bar formatter: Fuubar.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.gem
 .DS_Store
-/Gemfile.lock
 /coverage/*
 /tmp/*
 .bundle

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---format progress
+--format Fuubar

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ addons:
     - git-svn
 
 script:
-  - bundle exec rspec
+  - bundle exec rspec --format progress

--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,11 @@ end
 group :test do
   gem 'factory_bot', '~> 4.8.2'
   gem 'faker', '~> 1.8.4'
+  gem 'fuubar', '~> 2.2.0'
   gem 'simplecov', require: false
 end
 
 group :development, :test do
   gem 'bundler-audit', '~> 0.6.0', require: false
-  gem "appraisal"
+  gem 'appraisal'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,96 @@
+PATH
+  remote: .
+  specs:
+    gitlab_git (11.0.0)
+      activesupport (>= 4.0)
+      charlock_holmes (~> 0.7.3)
+      github-linguist (>= 5.1, < 5.4)
+      rugged (~> 0.26.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    appraisal (2.2.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+    bundler-audit (0.6.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
+    charlock_holmes (0.7.5)
+    coderay (1.1.2)
+    concurrent-ruby (1.0.5)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    escape_utils (1.1.1)
+    factory_bot (4.8.2)
+      activesupport (>= 3.0.0)
+    faker (1.8.4)
+      i18n (~> 0.5)
+    fuubar (2.2.0)
+      rspec-core (~> 3.0)
+      ruby-progressbar (~> 1.4)
+    github-linguist (5.3.1)
+      charlock_holmes (~> 0.7.5)
+      escape_utils (~> 1.1.0)
+      mime-types (>= 1.19)
+      rugged (>= 0.25.1)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
+    json (2.1.0)
+    method_source (0.9.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    minitest (5.10.3)
+    pry (0.11.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rake (12.1.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+    ruby-progressbar (1.9.0)
+    rugged (0.26.0)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    thor (0.20.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  appraisal
+  bundler-audit (~> 0.6.0)
+  factory_bot (~> 4.8.2)
+  faker (~> 1.8.4)
+  fuubar (~> 2.2.0)
+  gitlab_git!
+  pry
+  rake
+  rspec (~> 3.7.0)
+  simplecov
+
+BUNDLED WITH
+   1.15.4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'faker'
 require 'factory_bot'
 require 'gitlab_git'
 require 'pry'
+require 'fuubar'
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }
 
@@ -22,4 +23,8 @@ RSpec.configure do |config|
   config.before(:suite) do
     FactoryBot.find_definitions
   end
+
+  config.fuubar_progress_bar_options = {format: '[%B] %c/%C',
+                                        progress_mark: '#',
+                                        remainder_mark: '-'}
 end


### PR DESCRIPTION
This replaces the `progress` formatter (the dots) by the Fuubar formatter (a progress bar) for the development machine. This does not affect Travis.

To see it in action, either check out this branch and run `rspec` or [watch this video of 20 seconds](https://vimeo.com/16845253).