### PR TITLE
Ontohub backend 97 conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,16 @@ Gitlab::Git::Wrapper.new(path).pull
 The `Gitlab::Git::Wrapper` adds convenience-methods to create commits.
 All of these need a committer and an author object as well as some commit options.
 
+If the optional parameter `previous_head_sha` is supplied to any of the following methods, and the HEAD of the branch is different from that parameter (i.e. the branch has changed since authoring the commit-changes) Gitlab::Git::Wrapper attempts to merge the new commit on top of the current HEAD.
+If merging is not possible, a `Gitlab::Git::Committing::HeadChangedError` is raised that contains data about the conflicts in its `conflicts` attribute.
+If the parameter `previous_head_sha` is not set (`nil`), then the new commit overwrites possible changes to the branch that occurred in the meantime.
+
 ```ruby
 # Preliminary objects - the time and update_ref keys are optional.
 author = {name: 'author', email: 'author@example.com', time: Time.now}
 committer = {name: 'committer', email: 'committer@example.com', time: Time.now}
 commit_info = {message: 'Some message', branch: 'master', update_ref: true}
+previous_head_sha = wrapper.commit('master').id # optional, set long before creating the commit
 
 # Create a new file with a single commit
 wrapper.create_file({file: {path: 'path/to/file.txt',
@@ -203,7 +208,7 @@ wrapper.create_file({file: {path: 'path/to/file.txt',
                            encoding: 'plain'}, # supported: 'plain', 'base64', default: 'plain'
                      author: author,
                      committer: committer,
-                     commit: commit_info})
+                     commit: commit_info}, previous_head_sha) # previous_head_sha is optional (default: nil)
   # => 'c7454ef14304af343b6bc8b1545e224364d5a44b'
 
 # Update file contents with a single commit
@@ -212,7 +217,7 @@ wrapper.update_file({file: {path: 'path/to/file.txt',
                            encoding: 'plain'}, # supported: 'plain', 'base64', default: 'plain'
                      author: author,
                      committer: committer,
-                     commit: commit_info})
+                     commit: commit_info}, previous_head_sha) # previous_head_sha is optional (default: nil)
   # => 'c7454ef14304af343b6bc8b1545e224364d5a44b'
 
 # Update file contents and move the file with a single commit
@@ -222,7 +227,7 @@ wrapper.rename_and_update_file({file: {path: 'path/to/other_file.txt',
                                       encoding: 'plain'}, # supported: 'plain', 'base64', default: 'plain'
                                 author: author,
                                 committer: committer,
-                                commit: commit_info})
+                                commit: commit_info}, previous_head_sha) # previous_head_sha is optional (default: nil)
   # => 'c7454ef14304af343b6bc8b1545e224364d5a44b'
 
 # Rename a file with a single commit
@@ -230,19 +235,19 @@ wrapper.rename_file({file: {path: 'path/to/other_file.txt',
                             previous_path: 'path/to/file.txt'}
                      author: author,
                      committer: committer,
-                     commit: commit_info})
+                     commit: commit_info}, previous_head_sha) # previous_head_sha is optional (default: nil)
   # => 'c7454ef14304af343b6bc8b1545e224364d5a44b'
 
 # Remove a file with a single commit
 wrapper.update_file({file: {path: 'path/to/file.txt'},
                      author: author,
                      committer: committer,
-                     commit: commit_info})
+                     commit: commit_info}, previous_head_sha) # previous_head_sha is optional (default: nil)
   # => 'c7454ef14304af343b6bc8b1545e224364d5a44b'
 
 # Create a directory (with a .gitkeep file) with a single commit
 wrapper.mkdir('path/to/file.txt',
-              {author: author, committer: committer, commit: commit_info})
+              {author: author, committer: committer, commit: commit_info}, previous_head_sha) # previous_head_sha is optional (default: nil)
   # => 'c7454ef14304af343b6bc8b1545e224364d5a44b'
 
 # Create a single commit with multiple actions:
@@ -268,7 +273,7 @@ files =
 wrapper.commit_multichange({files: files,
                             author: author,
                             committer: committer,
-                            commit: commit_info})
+                            commit: commit_info}, previous_head_sha) # previous_head_sha is optional (default: nil)
   # => 'c7454ef14304af343b6bc8b1545e224364d5a44b'
 ```
 

--- a/lib/gitlab_git/committing.rb
+++ b/lib/gitlab_git/committing.rb
@@ -273,11 +273,21 @@ module Gitlab
         options[:commit][:branch] ||= 'master'
         options[:commit][:update_ref] = true if options[:commit][:update_ref].nil?
         normalize_ref(options)
+        normalize_update_ref(options)
       end
 
       def normalize_ref(options)
         return if options[:commit][:branch].start_with?('refs/')
         options[:commit][:branch] = 'refs/heads/' + options[:commit][:branch]
+      end
+
+      def normalize_update_ref(options)
+        options[:commit][:update_ref] =
+          if options[:commit][:update_ref].nil?
+            true
+          else
+            options[:commit][:update_ref]
+          end
       end
 
       # This method does the actual committing. Use this mutexed with the git
@@ -287,43 +297,48 @@ module Gitlab
       # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/MethodLength
       def commit_with(options, previous_head_sha)
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/MethodLength
         insert_defaults(options)
         prevent_overwriting_previous_changes(options, previous_head_sha)
 
-        commit = options[:commit]
-        ref = commit[:branch]
-        ref = 'refs/heads/' + ref unless ref.start_with?('refs/')
-        update_ref = commit[:update_ref].nil? ? true : commit[:update_ref]
-
         index = Gitlab::Git::Index.new(gitlab)
+        parents, last_commit = parents_and_last_commit(options)
+        index.read_tree(last_commit.tree) if last_commit
 
+        yield(index)
+        create_commit(index, options, parents)
+      end
+
+      def parents_and_last_commit(options)
         parents = []
+        last_commit = nil
         unless empty?
-          rugged_ref = rugged.references[ref]
+          rugged_ref = rugged.references[options[:commit][:branch]]
           unless rugged_ref
             raise Gitlab::Git::Repository::InvalidRef, 'Invalid branch name'
           end
           last_commit = rugged_ref.target
-          index.read_tree(last_commit.tree)
           parents = [last_commit]
         end
+        [parents, last_commit]
+      end
 
-        yield(index)
-
+      def create_commit(index, options, parents)
         opts = {}
         opts[:tree] = index.write_tree
         opts[:author] = options[:author]
         opts[:committer] = options[:committer]
-        opts[:message] = commit[:message]
+        opts[:message] = options[:commit][:message]
         opts[:parents] = parents
-        opts[:update_ref] = ref if update_ref
+        if options[:commit][:update_ref]
+          opts[:update_ref] = options[:commit][:branch]
+        end
 
         Rugged::Commit.create(rugged, opts)
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/gitlab_git/committing/merge.rb
+++ b/lib/gitlab_git/committing/merge.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Gitlab
+  module Git
+    module Committing
+      # Methods for merging a commit into another if the previous_head_sha is
+      # an ancestor of the current HEAD of a branch.
+      module Merge
+        def merge_if_needed(options, previous_head_sha)
+          return [:noop, nil] unless diverged?(options, previous_head_sha)
+
+          commit_sha = merge(options, previous_head_sha)
+          return [:merge_commit_created, commit_sha]
+        end
+
+        def diverged?(options, previous_head_sha)
+          !previous_head_sha.nil? &&
+            branch_sha(options[:commit][:branch]) != previous_head_sha
+        end
+
+        def merge(options, previous_head_sha)
+          user_commit = create_user_commit(options, previous_head_sha)
+          base_commit = commit(options[:commit][:branch]).raw_commit
+
+          index = rugged.merge_commits(base_commit, user_commit)
+
+          raise_head_changed_error(index.conflicts, options) if index.conflicts?
+          tree_id = index.write_tree(rugged)
+          found_conflicts = conflicts(options, base_commit, user_commit)
+          if found_conflicts.any?
+            raise_head_changed_error(found_conflicts, options)
+          end
+          create_merging_commit(base_commit, index, tree_id, options)
+        end
+
+        def conflicts(options, base_commit, user_commit)
+          options[:files].map do |file|
+            case file[:action]
+            when :update
+              conflict_on_update(base_commit, user_commit, file[:path])
+            when :rename_and_update
+              conflict_on_update(base_commit, user_commit, file[:previous_path])
+            end
+          end.compact
+        end
+
+        def conflict_on_update(base_commit, user_commit, path)
+          base_blob = blob(base_commit.oid, path)
+          return nil unless base_blob.nil?
+
+          ancestor_blob = blob(base_commit.parents.first.oid, path)
+          user_blob = blob(user_commit.oid, path)
+          result = {}
+          result[:ancestor] = conflict_hash(ancestor_blob, 1) if ancestor_blob
+          result[:ours] = nil
+          result[:theirs] = conflict_hash(user_blob, 3) if user_blob
+          result
+        end
+
+        def conflict_hash(blob_object, stage)
+          {path: blob_object.path,
+           oid: blob_object.id,
+           dev: 0,
+           ino: 0,
+           mode: blob_object.mode.to_i(8),
+           gid: 0,
+           uid: 0,
+           file_size: 0,
+           valid: false,
+           stage: stage,
+           ctime: Time.at(0),
+           mtime: Time.at(0)}
+        end
+
+        def create_user_commit(options, previous_head_sha)
+          with_temp_user_reference(options, previous_head_sha) do |reference|
+            new_options = options.dup
+            new_options[:commit] = options[:commit].dup
+            new_options[:commit][:branch] = reference.name
+            new_options[:commit][:update_ref] = false
+            commit_sha = commit_multichange(new_options)
+            rugged.lookup(commit_sha)
+          end
+        end
+
+        def with_temp_user_reference(options, previous_head_sha)
+          refname = "#{Time.now.to_f.to_s.tr('.', '')}_#{SecureRandom.hex(20)}"
+          full_refname = "refs/merges/user/#{refname}"
+          reference = rugged.references.create(full_refname, previous_head_sha)
+          yield(reference)
+        ensure
+          rugged.references.delete(reference)
+        end
+
+        def create_merging_commit(parent_commit, index, tree_id, options)
+          parents = [parent_commit.oid]
+          create_commit(index, tree_id, options, parents)
+        end
+
+        def raise_head_changed_error(conflicts, options)
+          message = <<MESSAGE
+The branch has changed since editing and cannot be merged automatically.
+MESSAGE
+          raise HeadChangedError.new(message, conflicts, options)
+        end
+      end
+    end
+  end
+end

--- a/spec/committing_spec.rb
+++ b/spec/committing_spec.rb
@@ -469,7 +469,8 @@ CONTENT
           expect(e.conflicts).
             to match([{ancestor: expected_conflict_ancestor,
                        ours: expected_conflict_ours,
-                       theirs: expected_conflict_theirs}])
+                       theirs: expected_conflict_theirs,
+                       merge_info: expected_conflict_merge_info}])
         end
       end
 
@@ -516,6 +517,12 @@ CONTENT
         let(:expected_conflict_ancestor) { be_present }
         let(:expected_conflict_ours) { be_present }
         let(:expected_conflict_theirs) { be_present }
+        let(:expected_conflict_merge_info) do
+          match(automergeable: false,
+                path: updated_file,
+                filemode: be_present,
+                data: match(/<{7}.*={7}.*>{7}/m))
+        end
       end
     end
 
@@ -539,6 +546,7 @@ CONTENT
         let(:expected_conflict_ancestor) { be_present }
         let(:expected_conflict_ours) { be_present }
         let(:expected_conflict_theirs) { be(nil) }
+        let(:expected_conflict_merge_info) { be(nil) }
       end
     end
 
@@ -556,6 +564,7 @@ CONTENT
         let(:expected_conflict_ancestor) { be_present }
         let(:expected_conflict_ours) { be_present }
         let(:expected_conflict_theirs) { be(nil) }
+        let(:expected_conflict_merge_info) { be(nil) }
       end
     end
 
@@ -574,6 +583,7 @@ CONTENT
         let(:expected_conflict_ancestor) { be_present }
         let(:expected_conflict_ours) { be(nil) }
         let(:expected_conflict_theirs) { be_present }
+        let(:expected_conflict_merge_info) { be(nil) }
       end
     end
   end

--- a/spec/committing_spec.rb
+++ b/spec/committing_spec.rb
@@ -316,100 +316,264 @@ RSpec.describe(Gitlab::Git::Committing) do
   context 'when the branch has changed in the meantime' do
     subject { create(:git) }
     let(:branch) { 'master' }
-    let(:invalid_sha) { '0' * 40 }
+    let(:existing_file_unchanged) { generate(:filepath) }
+    let(:existing_file_changed) { generate(:filepath) }
+    let(:existing_file_added) { generate(:filepath) }
+    let(:existing_file_removed) { generate(:filepath) }
+    let(:existing_content) do
+      <<CONTENT
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+line 7
+line 8
+line 9
+line 10
+CONTENT
+    end
+    let(:commit_before1) do
+      subject.create_file(create(:git_commit_info,
+                                 filepath: existing_file_unchanged,
+                                 content: existing_content,
+                                 branch: branch))
+    end
+    let(:commit_before2) do
+      subject.create_file(create(:git_commit_info,
+                                 filepath: existing_file_removed,
+                                 content: existing_content,
+                                 branch: branch))
+    end
+    let(:commit_base) do
+      subject.create_file(create(:git_commit_info,
+                                 filepath: existing_file_changed,
+                                 content: existing_content,
+                                 branch: branch))
+    end
+    let(:commit_after1) do
+      subject.create_file(create(:git_commit_info,
+                                 filepath: existing_file_added,
+                                 content: existing_content,
+                                 branch: branch))
+    end
+    let(:commit_after2) do
+      subject.update_file(create(:git_commit_info,
+                                 filepath: existing_file_changed,
+                                 content: existing_content.upcase,
+                                 branch: branch))
+    end
+    let(:commit_after3) do
+      subject.remove_file(create(:git_commit_info,
+                                 filepath: existing_file_removed,
+                                 branch: branch))
+    end
+    let(:commit_latest) { commit_after3 }
 
-    context 'adding a file' do
+    # create the commits in order
+    before do
+      commit_before1
+      commit_before2
+      commit_base
+      commit_after1
+      commit_after2
+      commit_after3
+    end
+
+    let(:previous_head_sha) { commit_base }
+
+    context 'creating a new file' do
+      let(:new_file) { generate(:filepath) }
+      let(:new_content) { generate(:content) }
+      let(:new_commit) do
+        subject.create_file(create(:git_commit_info,
+                                   filepath: new_file,
+                                   content: new_content,
+                                   branch: branch),
+                            previous_head_sha)
+      end
+
       before do
-        subject.create_file(create(:git_commit_info,
-                                   filepath: 'first_file',
-                                   branch: branch))
+        new_commit
       end
 
-      let(:filepath) { generate(:filepath) }
-
-      it 'raises an error' do
-        expect do
-          subject.create_file(create(:git_commit_info,
-                                     filepath: filepath,
-                                     branch: branch),
-                              invalid_sha)
-        end.to raise_error(Gitlab::Git::Committing::HeadChangedError)
-      end
-    end
-
-    context 'updating a file' do
-      let(:filepath) { generate(:filepath) }
-      let!(:sha) do
-        subject.create_file(create(:git_commit_info,
-                                   filepath: filepath,
-                                   branch: branch))
+      it 'sets the HEAD of the branch to the latest commit' do
+        expect(subject.branch_sha(branch)).to eq(new_commit)
       end
 
-      it 'raises an error' do
-        expect do
-          subject.update_file(create(:git_commit_info,
-                                     filepath: filepath,
-                                     branch: branch),
-                              invalid_sha)
-        end.to raise_error(Gitlab::Git::Committing::HeadChangedError)
+      it 'sets the content of the new file' do
+        expect(subject.blob(branch, new_file).data).to eq(new_content)
+      end
+
+      it 'keeps the content of the existing_file_unchanged' do
+        expect(subject.blob(branch, existing_file_unchanged).data).
+          to eq(existing_content)
+      end
+
+      it 'keeps the content of the existing_file_changed' do
+        expect(subject.blob(branch, existing_file_changed).data).
+          to eq(existing_content.upcase)
+      end
+
+      it 'keeps the content of the existing_file_added' do
+        expect(subject.blob(branch, existing_file_added).data).
+          to eq(existing_content)
       end
     end
 
-    context 'renaming a file' do
-      let(:filepath1) { generate(:filepath) }
-      let(:filepath2) { generate(:filepath) }
-      let!(:sha) do
-        subject.create_file(create(:git_commit_info,
-                                   filepath: filepath1,
-                                   branch: branch))
+    context 'updating an unchanged file' do
+      let(:updated_file) { existing_file_unchanged }
+      let(:new_content) { generate(:content) }
+      let(:new_commit) do
+        subject.update_file(create(:git_commit_info,
+                                   filepath: updated_file,
+                                   content: new_content,
+                                   branch: branch),
+                            previous_head_sha)
       end
-      let!(:content1) { subject.blob(branch, filepath1).data }
 
-      it 'raises an error' do
-        expect do
-          commit_info = create(:git_commit_info,
-                               filepath: filepath2,
-                               branch: branch)
-          commit_info[:file].merge!(previous_path: filepath1,
-                                    content: content1)
-          subject.rename_file(commit_info, invalid_sha)
-        end.to raise_error(Gitlab::Git::Committing::HeadChangedError)
-      end
-    end
-
-    context 'deleting a file' do
-      let(:filepath) { generate(:filepath) }
-      let!(:sha) do
-        subject.create_file(create(:git_commit_info,
-                                   filepath: filepath,
-                                   branch: branch))
-      end
-      it 'raises an error' do
-        expect do
-          commit_info = create(:git_commit_info,
-                               filepath: filepath,
-                               branch: branch)
-          commit_info[:file].delete(:content)
-          subject.remove_file(commit_info, invalid_sha)
-        end.to raise_error(Gitlab::Git::Committing::HeadChangedError)
-      end
-    end
-
-    context 'creating a directory' do
       before do
-        subject.create_file(create(:git_commit_info,
-                                   filepath: 'first_file',
-                                   branch: branch))
+        new_commit
       end
 
-      let!(:path) { 'dir/with/subdir' }
+      it 'sets the HEAD of the branch to the latest commit' do
+        expect(subject.branch_sha(branch)).to eq(new_commit)
+      end
 
+      it 'sets the content of the upated file' do
+        expect(subject.blob(branch, updated_file).data).to eq(new_content)
+      end
+
+      it 'keeps the content of the existing_file_changed' do
+        expect(subject.blob(branch, existing_file_changed).data).
+          to eq(existing_content.upcase)
+      end
+
+      it 'keeps the content of the existing_file_added' do
+        expect(subject.blob(branch, existing_file_added).data).
+          to eq(existing_content)
+      end
+    end
+
+    shared_examples 'failing to commit' do
       it 'raises an error' do
-        expect do
-          options = create(:git_commit_info, branch: branch)
-          options.delete(:file)
-          subject.mkdir(path, options, invalid_sha)
-        end.to raise_error(Gitlab::Git::Committing::HeadChangedError)
+        expect { new_commit }.
+          to raise_error(Gitlab::Git::Committing::HeadChangedError)
+      end
+
+      it 'raises an error with the correct conflicts' do
+        begin
+          new_commit
+        rescue Gitlab::Git::Committing::HeadChangedError => e
+          expect(e.conflicts).
+            to match([{ancestor: expected_conflict_ancestor,
+                       ours: expected_conflict_ours,
+                       theirs: expected_conflict_theirs}])
+        end
+      end
+
+      context 'trying to commit' do
+        before do
+          begin
+            new_commit
+          rescue Gitlab::Git::Committing::HeadChangedError
+          end
+        end
+
+        it 'keeps the HEAD of the branch' do
+          expect(subject.branch_sha(branch)).to eq(commit_latest)
+        end
+
+        it 'keeps the content of the existing_file_unchanged' do
+          expect(subject.blob(branch, existing_file_unchanged).data).
+            to eq(existing_content)
+        end
+
+        it 'keeps the content of the existing_file_changed' do
+          expect(subject.blob(branch, existing_file_changed).data).
+            to eq(existing_content.upcase)
+        end
+
+        it 'keeps the content of the existing_file_added' do
+          expect(subject.blob(branch, existing_file_added).data).
+            to eq(existing_content)
+        end
+      end
+    end
+
+    context 'updating a changed file' do
+      let(:updated_file) { existing_file_changed }
+      let(:new_content) { generate(:content) }
+      let(:new_commit) do
+        subject.update_file(create(:git_commit_info,
+                                   filepath: updated_file,
+                                   content: new_content,
+                                   branch: branch),
+                            previous_head_sha)
+      end
+      include_examples 'failing to commit' do
+        let(:expected_conflict_ancestor) { be_present }
+        let(:expected_conflict_ours) { be_present }
+        let(:expected_conflict_theirs) { be_present }
+      end
+    end
+
+    context 'renaming and updating a changed file' do
+      let(:updated_file) { existing_file_changed }
+      let(:new_file) { generate(:filepath) }
+      let(:new_content) { generate(:content) }
+      let(:commit_info) do
+        info = create(:git_commit_info,
+                      filepath: updated_file,
+                      content: new_content,
+                      branch: branch)
+        info[:file][:previous_path] = info[:file][:path]
+        info[:file][:path] = new_file
+        info
+      end
+      let(:new_commit) do
+        subject.rename_and_update_file(commit_info, previous_head_sha)
+      end
+      include_examples 'failing to commit' do
+        let(:expected_conflict_ancestor) { be_present }
+        let(:expected_conflict_ours) { be_present }
+        let(:expected_conflict_theirs) { be(nil) }
+      end
+    end
+
+    context 'removing a changed file' do
+      let(:updated_file) { existing_file_changed }
+      let(:new_content) { generate(:content) }
+      let(:new_commit) do
+        subject.remove_file(create(:git_commit_info,
+                                   filepath: updated_file,
+                                   content: new_content,
+                                   branch: branch),
+                            previous_head_sha)
+      end
+      include_examples 'failing to commit' do
+        let(:expected_conflict_ancestor) { be_present }
+        let(:expected_conflict_ours) { be_present }
+        let(:expected_conflict_theirs) { be(nil) }
+      end
+    end
+
+    context 'updating a removed file' do
+      let(:updated_file) { existing_file_removed }
+      let(:new_content) { generate(:content) }
+      let(:new_commit) do
+        subject.update_file(create(:git_commit_info,
+                                   filepath: updated_file,
+                                   content: new_content,
+                                   branch: branch),
+                            previous_head_sha)
+      end
+
+      include_examples 'failing to commit' do
+        let(:expected_conflict_ancestor) { be_present }
+        let(:expected_conflict_ours) { be(nil) }
+        let(:expected_conflict_theirs) { be_present }
       end
     end
   end


### PR DESCRIPTION
This is the gitlab_git part of https://github.com/ontohub/ontohub-backend/issues/97.

The interface (except for the error) stays the same. If a commit is created after the HEAD of a branch has changed, a merge is attempted. If merging is not possible due to conflicts, conflict data is added to the Error that is raised.